### PR TITLE
Arreglar la comunicación entre el master y el sistema del riel

### DIFF
--- a/concept-test/firmware/Motor_code/Motor_code.ino
+++ b/concept-test/firmware/Motor_code/Motor_code.ino
@@ -50,6 +50,7 @@ void loop(){
 }
 
 void controler(){
+  // receiving command
   String command = "";
 
   while(Wire.available()){
@@ -62,8 +63,8 @@ void controler(){
   } 
   if (command[0] == 'R'){ // R --> Run
     start_round = true;
-    digitalWrite(enb_pin, 0);
-    digitalWrite(LED_BUILTIN, 1);
+    digitalWrite(enb_pin, 1);
+    digitalWrite(LED_BUILTIN, 1); // led running indicator
   }  
   if (command[0] == 'r'){ // r --> reset
     reset_system();
@@ -83,14 +84,17 @@ void set_speed(int motor_speed){
 }
 
 void reset_system(){
-  digitalWrite(enb_pin, 1); // disable for does not consume current
-  digitalWrite(dir_pin, 1);// counterclockwise by default
-  digitalWrite(signal_end_out, 1);
+  digitalWrite(enb_pin, 0); // disable for does not consume current
+  digitalWrite(dir_pin, 0);// counterclockwise by default
+
+  // produce a pulse to notify master about the resetting of the system
+  digitalWrite(signal_end_out, 1); 
   digitalWrite(signal_end_out, 0);
-  digitalWrite(LED_BUILTIN, 0);
+
+  digitalWrite(LED_BUILTIN, 0); // LED running indicator off
   start_round = false;
 }
 
 void go_back(){
-  digitalWrite(dir_pin, 0);
+  digitalWrite(dir_pin, 1); // changing the direction
 }

--- a/concept-test/firmware/master_code/master_code.ino
+++ b/concept-test/firmware/master_code/master_code.ino
@@ -55,24 +55,37 @@ void serialEvent() {
 
 void set_rpm() {
   /*to send "set speed" command to the slave in address 1 (motor) */
-  Wire.beginTransmission(0X01); // address 1 for motor controler
+
+  Wire.beginTransmission(0X01); // address 1 for motor controller
   Wire.write('S'); // S --> set Speed 
-  Wire.write(rpm_value);
+  String aux_rpm = String(rpm_value);
+  // it is necessary to send character by character
+  for(int i =0; i < aux_rpm.length(); i++ ) {
+    Wire.write(aux_rpm[i]);
+  }
   Wire.endTransmission();
 }
 
 void run_measurement() {
   /*to send "run" command to the slave in address 1 (motor) */
   measure_temp = true;
-  Wire.beginTransmission(0X01); // address 21 for motor controler
+
+  // first reset the system
+  Wire.beginTransmission(0X01); // address 1 for motor controller
+  Wire.write('r'); // R --> Start the round
+  Wire.endTransmission();
+
+  // then start the round
+  Wire.beginTransmission(0X01);
   Wire.write('R'); // R --> Start the round
   Wire.endTransmission();
 
-  Serial.println("Runing measurement");
+  Serial.println("Running measurement");
 }
 
 void end_measure(){
   measure_temp = false;
+  Serial.println("Run finished");
 }
 
 double readThermocouple() {


### PR DESCRIPTION
El motor no se movía porque el dispositivo maestro estaba transmitiendo mal los comandos. En la comunicación I2C es importante enviar carácter por carácter ya que solo permite la transmisión de 1 byte por vez. Por lo tanto, se cambió la parte del código en la que se le envía el comando de velocidad al esclavo para que el sistema pudiera configurarse de forma adecuada.

Esto resuelve el issue #2 